### PR TITLE
Case mismatch between loaded and declared class name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 shihjay2
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 TCPDI-merger. Merge PDF files using the TCPDI library.
 
 ###Make it work!
-1. `composer require rcamposp/tcpdi-merger`
-2. Copy the example directory. 
-3. Run it! `php example/test-php.php`
+1. `composer require shihjay2/tcpdi-merger`
+2. Copy the example directory.
+3. Run it!
 
 ###Example code
 ```
@@ -12,8 +12,8 @@ TCPDI-merger. Merge PDF files using the TCPDI library.
 
     require 'vendor/autoload.php';
 
-    use rcamposp\tcpdi_merger\MyTCPDI;
-    use rcamposp\tcpdi_merger\Merger;            
+    use shihjay2\tcpdi_merger\MyTCPDI;
+    use shihjay2\tcpdi_merger\Merger;            
 
     $m = new Merger(true);
     $m->addFromFile("example/A.pdf");

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,16 @@
 {
-    "name": "rcamposp/tcpdi-merger",
+    "name": "shihjay2/tcpdi-merger",
     "description": "PDF Importer that supports PDF versions 1.6+. Based on: https://github.com/pauln/tcpdi",
     "keywords": ["pdf", "merge", "concatenate"],
-    "homepage": "https://github.com/rcamposp/tcpdi-merger",
+    "homepage": "https://github.com/shihjay2/tcpdi-merger",
     "type": "library",
-    "license": "WTFPL",
+    "license": "MIT",
     "authors": [
+        {
+			"name" : "Michael Chen",
+			"role" : "Developer",
+			"homepage" : "https://github.com/shihjay2/"
+		},
         {
             "name": "Ricardo Campos",
             "email": "ricardocamposp@gmail.com"
@@ -13,11 +18,11 @@
     ],
     "autoload": {
         "psr-4": {
-            "rcamposp\\tcpdi_merger\\": "src/"
+            "shihjay2\\tcpdi_merger\\": "src/"
         }
     },
     "require": {
         "php": ">=5.3.0",
-        "tecnickcom/tcpdf": "^6.2"        
+        "tecnickcom/tcpdf": "^6.2"
     }
 }

--- a/example/test-pdf.php
+++ b/example/test-pdf.php
@@ -2,8 +2,8 @@
 
     require 'vendor/autoload.php';
 
-    use rcamposp\tcpdi_merger\MyTCPDI;
-    use rcamposp\tcpdi_merger\Merger;            
+    use shihjay2\tcpdi_merger\MyTCPDI;
+    use shihjay2\tcpdi_merger\Merger;
 
     $m = new Merger(true);
     $m->addFromFile("example/A.pdf");

--- a/src/Merger.php
+++ b/src/Merger.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace rcamposp\tcpdi_merger;
+namespace shihjay2\tcpdi_merger;
 
 #require_once("src/MyTCPDI.php");
 
@@ -9,16 +9,16 @@ class Merger{
 
     private $files = array();
 
-    private $output = "";   
+    private $output = "";
 
     private $tempDir;
 
     public function __construct($showPagination = false){
-        $this->tcpdi = new MyTCPDI($showPagination); //Default page format params        
+        $this->tcpdi = new MyTCPDI($showPagination); //Default page format params
     }
 
-    public function addRaw($pdf){
-        assert('is_string($pdf)');
+    public function addRaw($pdf)
+    {
         // Create temporary file
         $fname = $this->getTempFname();
         if (@file_put_contents($fname, $pdf) === false) {
@@ -26,43 +26,41 @@ class Merger{
         }
         $this->addFromFile($fname, true);
     }
-    
-    
-    public function addFromFile($fname, $cleanup = false){
-        assert('is_string($fname)');
-        assert('is_bool($cleanup)');
+
+
+    public function addFromFile($fname, $cleanup = false)
+    {
         if (!is_file($fname) || !is_readable($fname)) {
             throw new Exception("'$fname' is not a valid file");
         }
-     
         $this->files[] = array($fname, $cleanup);
     }
 
-    public function merge(){
+    public function merge()
+    {
         if (empty($this->files)) {
             throw new Exception("Unable to merge, no PDFs added");
         }
-
         $fname = '';
         try {
             $tcpdi = clone $this->tcpdi;
             foreach ($this->files as $fileData) {
                 list($fname, $cleanup) = $fileData;
-                
+
                 $iPageCount = $tcpdi->setSourceFile($fname);
-                // Add all pages                
+                // Add all pages
                 $pages = range(1, $iPageCount);
-                
+
                 // Add specified pages
                 foreach ($pages as $page) {
                     $template = $tcpdi->importPage($page);
                     $size = $tcpdi->getTemplateSize($template);
                     $orientation = ($size['w'] > $size['h']) ? 'L' : 'P';
-                    $tcpdi->AddPage($orientation, array($size['w'], $size['h']));                    
+                    $tcpdi->AddPage($orientation, array($size['w'], $size['h']));
                     $tcpdi->useTemplate($template);
                 }
             }
-            
+
             $output = $tcpdi->Output('', 'S');
             $tcpdi->cleanUp();
             foreach ($this->files as $fileData) {
@@ -71,31 +69,29 @@ class Merger{
                     unlink($fname);
                 }
             }
-            $this->files = array();            
-            $this->output = $output;            
+            $this->files = array();
+            $this->output = $output;
         } catch (Exception $e) {
             throw new Exception("FPDI: '{$e->getMessage()}' in '$fname'", 0, $e);
         }
     }
 
-    public function getRawOutput(){
+    public function getRawOutput()
+    {
         return $this->output;
     }
 
-    public function download($filename = 'document.pdf')
+    public function download($filename)
     {
-        
         header("Content-Type: application/pdf");
-        header('Content-Length: '.strlen($this->output));            
+        header('Content-Length: '.strlen($this->output));
         header('Content-disposition: attachment; filename="'.$filename.'"');
         echo $this->output;
-        
     }
 
-    public function save($path = 'example/document.pdf')
-    {
+    public function save($path){
         file_put_contents($path, $this->output);
-    }    
+    }
 
     /**
      * Create temporary file and return name
@@ -117,7 +113,7 @@ class Merger{
     {
         return $this->tempDir ?: sys_get_temp_dir();
     }
-	
+
 
     /**
      * Set directory path for temporary files

--- a/src/MyTCPDI.php
+++ b/src/MyTCPDI.php
@@ -1,22 +1,24 @@
 <?php
 
-namespace rcamposp\tcpdi_merger;
+namespace shihjay2\tcpdi_merger;
 // Include the main TCPDF library and TCPDI.
-use rcamposp\tcpdi_merger\tcpdi;  
+use shihjay2\tcpdi_merger\tcpdi;
 
 #Intended to extend stuff from the base TCPDF class
 class MyTCPDI extends TCPDI{
     protected $header_line_color = array(255,255,255);
 
     protected $showPagination;
-    
-    public function __construct($showPagination = false){        
+
+    public function __construct($showPagination = false)
+    {
         $this->showPagination = $showPagination;
         parent::__construct();
     }
 
     // Page footer
-	public function Footer() {
+	public function Footer()
+    {
         if($this->showPagination){
             // Position at 15 mm from bottom
             $this->SetY(-15);

--- a/src/fpdf_tpl.php
+++ b/src/fpdf_tpl.php
@@ -17,7 +17,7 @@
 //  limitations under the License.
 //
 
-namespace rcamposp\tcpdi_merger;
+namespace shihjay2\tcpdi_merger;
 
 class FPDF_TPL extends FPDF {
     /**
@@ -31,13 +31,13 @@ class FPDF_TPL extends FPDF {
      * @var int
      */
     var $tpl = 0;
-    
+
     /**
      * "In Template"-Flag
      * @var boolean
      */
     var $_intpl = false;
-    
+
     /**
      * Nameprefix of Templates used in Resources-Dictonary
      * @var string A String defining the Prefix used as Template-Object-Names. Have to beginn with an /
@@ -49,14 +49,14 @@ class FPDF_TPL extends FPDF {
      * @var array
      */
     var $_res = array();
-    
+
     /**
      * Last used Template data
      *
      * @var array
      */
     var $lastUsedTemplateData = array();
-    
+
     /**
      * Start a Template
      *
@@ -80,7 +80,7 @@ class FPDF_TPL extends FPDF {
     		$this->Error('This method is only usable with FPDF. Use TCPDF methods startTemplate() instead.');
     		return;
     	}
-    	
+
         if ($this->page <= 0)
             $this->error("You have to add a page to fpdf first!");
 
@@ -118,7 +118,7 @@ class FPDF_TPL extends FPDF {
         );
 
         $this->SetAutoPageBreak(false);
-        
+
         // Define own high and width to calculate possitions correct
         $this->h = $h;
         $this->w = $w;
@@ -130,13 +130,13 @@ class FPDF_TPL extends FPDF {
         if ($this->CurrentFont) {
             $fontkey = $this->FontFamily . $this->FontStyle;
 		    $this->_res['tpl'][$this->tpl]['fonts'][$fontkey] =& $this->fonts[$fontkey];
-            
+
         	$this->_out(sprintf('BT /F%d %.2f Tf ET', $this->CurrentFont['i'], $this->FontSizePt));
         }
-        
+
         return $this->tpl;
     }
-    
+
     /**
      * End Template
      *
@@ -149,9 +149,9 @@ class FPDF_TPL extends FPDF {
         	$args = func_get_args();
         	return call_user_func_array(array($this, 'TCPDF::endTemplate'), $args);
         }
-        
+
         if ($this->_intpl) {
-            $this->_intpl = false; 
+            $this->_intpl = false;
             $tpl =& $this->tpls[$this->tpl];
             $this->SetXY($tpl['o_x'], $tpl['o_y']);
             $this->tMargin = $tpl['o_tMargin'];
@@ -160,22 +160,22 @@ class FPDF_TPL extends FPDF {
             $this->h = $tpl['o_h'];
             $this->w = $tpl['o_w'];
             $this->SetAutoPageBreak($tpl['o_AutoPageBreak'], $tpl['o_bMargin']);
-            
+
             $this->FontFamily = $tpl['o_FontFamily'];
 			$this->FontStyle = $tpl['o_FontStyle'];
 			$this->FontSizePt = $tpl['o_FontSizePt'];
 			$this->FontSize = $tpl['o_FontSize'];
-        	
+
 			$fontkey = $this->FontFamily . $this->FontStyle;
 			if ($fontkey)
             	$this->CurrentFont =& $this->fonts[$fontkey];
-            
+
             return $this->tpl;
         } else {
             return false;
         }
     }
-    
+
     /**
      * Use a Template in current Page or other Template
      *
@@ -196,30 +196,30 @@ class FPDF_TPL extends FPDF {
     function useTemplate($tplidx, $_x = null, $_y = null, $_w = 0, $_h = 0) {
         if ($this->page <= 0)
         	$this->error('You have to add a page first!');
-        
+
         if (!isset($this->tpls[$tplidx]))
             $this->error('Template does not exist!');
-            
+
         if ($this->_intpl) {
             $this->_res['tpl'][$this->tpl]['tpls'][$tplidx] =& $this->tpls[$tplidx];
         }
-        
+
         $tpl =& $this->tpls[$tplidx];
         $w = $tpl['w'];
         $h = $tpl['h'];
-        
+
         if ($_x == null)
             $_x = 0;
         if ($_y == null)
             $_y = 0;
-            
+
         $_x += $tpl['x'];
         $_y += $tpl['y'];
-        
+
         $wh = $this->getTemplateSize($tplidx, $_w, $_h);
         $_w = $wh['w'];
         $_h = $wh['h'];
-    
+
         $tData = array(
             'x' => $this->x,
             'y' => $this->y,
@@ -231,15 +231,15 @@ class FPDF_TPL extends FPDF {
             'ty' =>  ($this->h - $_y - $_h),
             'lty' => ($this->h - $_y - $_h) - ($this->h - $h) * ($_h / $h)
         );
-        
-        $this->_out(sprintf('q %.4F 0 0 %.4F %.4F %.4F cm', $tData['scaleX'], $tData['scaleY'], $tData['tx'] * $this->k, $tData['ty'] * $this->k)); // Translate 
+
+        $this->_out(sprintf('q %.4F 0 0 %.4F %.4F %.4F cm', $tData['scaleX'], $tData['scaleY'], $tData['tx'] * $this->k, $tData['ty'] * $this->k)); // Translate
         $this->_out(sprintf('%s%d Do Q', $this->tplprefix, $tplidx));
 
         $this->lastUsedTemplateData = $tData;
-        
+
         return array('w' => $_w, 'h' => $_h);
     }
-    
+
     /**
      * Get The calculated Size of a Template
      *
@@ -257,7 +257,7 @@ class FPDF_TPL extends FPDF {
         $tpl =& $this->tpls[$tplidx];
         $w = $tpl['w'];
         $h = $tpl['h'];
-        
+
         if ($_w == 0 and $_h == 0) {
             $_w = $w;
             $_h = $h;
@@ -267,31 +267,31 @@ class FPDF_TPL extends FPDF {
     		$_w = $_h * $w / $h;
     	if($_h == 0)
     		$_h = $_w * $h / $w;
-    		
+
         return array("w" => $_w, "h" => $_h);
     }
-    
+
     /**
      * See FPDF/TCPDF-Documentation ;-)
      */
     public function SetFont($family, $style='', $size=null, $fontfile='', $subset='default', $out=true) {
-        
+
         if (is_subclass_of($this, 'TCPDF')) {
         	$args = func_get_args();
         	return call_user_func_array(array($this, 'TCPDF::SetFont'), $args);
         }
-        
+
         parent::SetFont($family, $style, $size);
-       
+
         $fontkey = $this->FontFamily . $this->FontStyle;
-        
+
         if ($this->_intpl) {
             $this->_res['tpl'][$this->tpl]['fonts'][$fontkey] =& $this->fonts[$fontkey];
         } else {
             $this->_res['page'][$this->page]['fonts'][$fontkey] =& $this->fonts[$fontkey];
         }
     }
-    
+
     /**
      * See FPDF/TCPDF-Documentation ;-)
      */
@@ -304,17 +304,17 @@ class FPDF_TPL extends FPDF {
         	$args = func_get_args();
 			return call_user_func_array(array($this, 'TCPDF::Image'), $args);
         }
-        
+
         $ret = parent::Image($file, $x, $y, $w, $h, $type, $link);
         if ($this->_intpl) {
             $this->_res['tpl'][$this->tpl]['images'][$file] =& $this->images[$file];
         } else {
             $this->_res['page'][$this->page]['images'][$file] =& $this->images[$file];
         }
-        
+
         return $ret;
     }
-    
+
     /**
      * See FPDF-Documentation ;-)
      *
@@ -325,10 +325,10 @@ class FPDF_TPL extends FPDF {
         	$args = func_get_args();
         	return call_user_func_array(array($this, 'TCPDF::AddPage'), $args);
         }
-        
+
         if ($this->_intpl)
             $this->Error('Adding pages in templates isn\'t possible!');
-            
+
         parent::AddPage($orientation, $format);
     }
 
@@ -340,35 +340,35 @@ class FPDF_TPL extends FPDF {
         	$args = func_get_args();
 			return call_user_func_array(array($this, 'TCPDF::Link'), $args);
         }
-        
+
         if ($this->_intpl)
             $this->Error('Using links in templates aren\'t possible!');
-            
+
         parent::Link($x, $y, $w, $h, $link);
     }
-    
+
     function AddLink() {
     	if (is_subclass_of($this, 'TCPDF')) {
         	$args = func_get_args();
 			return call_user_func_array(array($this, 'TCPDF::AddLink'), $args);
         }
-        
+
         if ($this->_intpl)
             $this->Error('Adding links in templates aren\'t possible!');
         return parent::AddLink();
     }
-    
+
     function SetLink($link, $y = 0, $page = -1) {
     	if (is_subclass_of($this, 'TCPDF')) {
         	$args = func_get_args();
 			return call_user_func_array(array($this, 'TCPDF::SetLink'), $args);
         }
-        
+
         if ($this->_intpl)
             $this->Error('Setting links in templates aren\'t possible!');
         parent::SetLink($link, $y, $page);
     }
-    
+
     /**
      * Private Method that writes the form xobjects
      */
@@ -393,13 +393,13 @@ class FPDF_TPL extends FPDF {
                 // ury
                 ($tpl['h'] - $tpl['y']) * $this->k
             ));
-            
+
             if ($tpl['x'] != 0 || $tpl['y'] != 0) {
                 $this->_out(sprintf('/Matrix [1 0 0 1 %.5F %.5F]',
                      -$tpl['x'] * $this->k * 2, $tpl['y'] * $this->k * 2
                 ));
             }
-            
+
             $this->_out('/Resources ');
 
             $this->_out('<</ProcSet [/PDF /Text /ImageB /ImageC /ImageI]');
@@ -409,7 +409,7 @@ class FPDF_TPL extends FPDF {
             		$this->_out('/F' . $font['i'] . ' ' . $font['n'] . ' 0 R');
             	$this->_out('>>');
             }
-        	if(isset($this->_res['tpl'][$tplidx]['images']) && count($this->_res['tpl'][$tplidx]['images']) || 
+        	if(isset($this->_res['tpl'][$tplidx]['images']) && count($this->_res['tpl'][$tplidx]['images']) ||
         	   isset($this->_res['tpl'][$tplidx]['tpls']) && count($this->_res['tpl'][$tplidx]['tpls']))
         	{
                 $this->_out('/XObject <<');
@@ -424,13 +424,13 @@ class FPDF_TPL extends FPDF {
                 $this->_out('>>');
         	}
         	$this->_out('>>');
-        	
+
         	$this->_out('/Length ' . strlen($p) . ' >>');
     		$this->_putstream($p);
     		$this->_out('endobj');
         }
     }
-    
+
     /**
      * Overwritten to add _putformxobjects() after _putimages()
      *
@@ -439,10 +439,10 @@ class FPDF_TPL extends FPDF {
         parent::_putimages();
         $this->_putformxobjects();
     }
-    
+
     function _putxobjectdict() {
         parent::_putxobjectdict();
-        
+
         if (count($this->tpls)) {
             foreach($this->tpls as $tplidx => $tpl) {
                 $this->_out(sprintf('%s%d %d 0 R', $this->tplprefix, $tplidx, $tpl['n']));

--- a/src/tcpdi.php
+++ b/src/tcpdi.php
@@ -20,12 +20,12 @@
 
 // Dummy shim to allow unmodified use of fpdf_tpl
 
-namespace rcamposp\tcpdi_merger;
+namespace shihjay2\tcpdi_merger;
 
-use rcamposp\tcpdi_merger\fpdf_tpl;  
-use rcamposp\tcpdi_merger\tcpdi_parser;
+use shihjay2\tcpdi_merger\fpdf_tpl;
+use shihjay2\tcpdi_merger\tcpdi_parser;
 
-class FPDF extends \TCPDF {}  
+class FPDF extends \TCPDF {}
 
 class TCPDI extends FPDF_TPL {
     /**

--- a/src/tcpdi.php
+++ b/src/tcpdi.php
@@ -627,7 +627,7 @@ class TCPDI extends FPDF_TPL {
 
                 reset ($value[1]);
 
-                while (list($k, $v) = each($value[1])) {
+                foreach ($value[1] as $k => $v) {
                     $this->_straightOut($k . ' ');
                     $this->pdf_write_value($v);
                 }

--- a/src/tcpdi_parser.php
+++ b/src/tcpdi_parser.php
@@ -485,7 +485,7 @@ class tcpdi_parser {
             $v = $sarr[$key];
             if (($key == '/Type') AND ($v[0] == PDF_TYPE_TOKEN AND ($v[1] == 'XRef'))) {
                 $valid_crs = true;
-            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1] >= 2))) {
+            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND ($v[1] >= 2))) {
                 // first object number in the subsection
                 $index_first = intval($v[1][0][1]);
                 // number of entries in the subsection

--- a/src/tcpdi_parser.php
+++ b/src/tcpdi_parser.php
@@ -50,7 +50,7 @@
 // include class for decoding filters
 #require_once(dirname(__FILE__).'/include/tcpdf_filters.php');
 
-namespace rcamposp\tcpdi_merger;
+namespace shihjay2\tcpdi_merger;
 
 if (!defined ('PDF_TYPE_NULL'))
     define ('PDF_TYPE_NULL', 0);


### PR DESCRIPTION
Case mismatch between loaded and declared class names: "shihjay2\tcpdi_merger\fpdf_tpl" vs "shihjay2\tcpdi_merger\FPDF_TPL". Error prevents further execution of the code.